### PR TITLE
Optimizer helper functions

### DIFF
--- a/tensorflow_lattice/python/estimators/BUILD
+++ b/tensorflow_lattice/python/estimators/BUILD
@@ -191,3 +191,25 @@ py_test(
         "//tensorflow_lattice/python:test_data",
     ],
 )
+
+py_library(
+    name = "optimizers",
+    srcs = ["optimizers.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@org_tensorflow//tensorflow:tensorflow_py",
+    ],
+)
+
+py_test(
+    name = "optimizers_test",
+    size = "large",
+    srcs = ["optimizers_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":calibrated_linear",
+				":optimizers",
+        "@org_tensorflow//tensorflow:tensorflow_py",
+        "//tensorflow_lattice/python:test_data",
+    ],
+)

--- a/tensorflow_lattice/python/estimators/BUILD
+++ b/tensorflow_lattice/python/estimators/BUILD
@@ -208,7 +208,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":calibrated_linear",
-				":optimizers",
+        ":optimizers",
         "@org_tensorflow//tensorflow:tensorflow_py",
         "//tensorflow_lattice/python:test_data",
     ],

--- a/tensorflow_lattice/python/estimators/calibrated_linear.py
+++ b/tensorflow_lattice/python/estimators/calibrated_linear.py
@@ -116,7 +116,7 @@ class _CalibratedLinear(calibrated_lib.Calibrated):
     # many features.
 
     self.check_hparams(hparams)
-    prediction = math_ops.reduce_sum(calibrated, 1, keep_dims=True)
+    prediction = math_ops.reduce_sum(calibrated, 1, keepdims=True)
     bias = variable_scope.get_variable(
         _SCOPE_BIAS_WEIGHT,
         initializer=array_ops.zeros(shape=[], dtype=self._dtype))

--- a/tensorflow_lattice/python/estimators/optimizers.py
+++ b/tensorflow_lattice/python/estimators/optimizers.py
@@ -1,0 +1,105 @@
+# Copyright 2018 The TensorFlow Lattice Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Optimizer helper functions."""
+from tensorflow.python.training import adagrad
+from tensorflow.python.training import gradient_descent
+from tensorflow.python.training import learning_rate_decay
+from tensorflow.python.training import training_util
+
+
+def gradient_descent_polynomial_decay(
+        decay_steps=10000,
+        end_learning_rate=0.0001,
+        power=0.5,
+        cycle=False,
+        name=None):
+  """Returns a gradient descent optimizer function with polynomial_decay.
+
+  See tesnorflow.training.learning_rate_decay.polynomial_decay how to set the
+  argument. This function returns a python callable that sets gradient descent
+  optimizer with a polynomialy decaying learning rate for tensorflow lattice
+  estimator training.
+
+  Args:
+    decay_steps: A scalar `int32` or `int64` `Tensor` or a Python number.
+      Must be positive.  See the decay computation above.
+    end_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+      Python number.  The minimal end learning rate.
+    power: A scalar `float32` or `float64` `Tensor` or a
+      Python number.  The power of the polynomial. Defaults to sqrt, 0.5.
+    cycle: A boolean, whether or not it should cycle beyond decay_steps.
+    name: String.  Optional name of the operation. Defaults to
+      'PolynomialDecay'.
+
+  Returns:
+    A python callable that accepts learning_rate and sets a gradient descent
+    optimizer with a polynomialy decaying learning rate for tensorflow lattice
+    estimator training.
+  """
+  def optimizer_fn(learning_rate=0.01):
+      global_step_tensor = training_util.get_or_create_global_step()
+      learning_rate = learning_rate_decay.polynomial_decay(
+              learning_rate=learning_rate,
+              global_step=global_step_tensor,
+              decay_steps=decay_steps,
+              end_learning_rate=end_learning_rate,
+              power=power,
+              cycle=cycle,
+              name=name)
+      return gradient_descent.GradientDescentOptimizer(learning_rate)
+  return optimizer_fn
+
+
+def adagrad_polynomial_decay(
+        decay_steps=10000,
+        end_learning_rate=0.0001,
+        power=0.5,
+        cycle=False,
+        name=None):
+  """Returns a adagrad optimizer function with polynomial_decay.
+
+  See tesnorflow.training.learning_rate_decay.polynomial_decay how to set the
+  argument. This function returns a python callable that sets adagrad optimizer
+  with a polynomialy decaying learning rate for tensorflow lattice estimator
+  training.
+
+  Args:
+    decay_steps: A scalar `int32` or `int64` `Tensor` or a Python number.
+      Must be positive.  See the decay computation above.
+    end_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+      Python number.  The minimal end learning rate.
+    power: A scalar `float32` or `float64` `Tensor` or a
+      Python number.  The power of the polynomial. Defaults to sqrt, 0.5.
+    cycle: A boolean, whether or not it should cycle beyond decay_steps.
+    name: String.  Optional name of the operation. Defaults to
+      'PolynomialDecay'.
+
+  Returns:
+    A python callable that accepts learning_rate and sets a gradient descent
+    optimizer with a polynomialy decaying learning rate for tensorflow lattice
+    estimator training.
+  """
+  def optimizer_fn(learning_rate=0.01):
+      global_step_tensor = training_util.get_or_create_global_step()
+      learning_rate = learning_rate_decay.polynomial_decay(
+              learning_rate=learning_rate,
+              global_step=global_step_tensor,
+              decay_steps=decay_steps,
+              end_learning_rate=end_learning_rate,
+              power=power,
+              cycle=cycle,
+              name=name)
+      return adagrad.AdagradOptimizer(learning_rate)
+  return optimizer_fn

--- a/tensorflow_lattice/python/estimators/optimizers_test.py
+++ b/tensorflow_lattice/python/estimators/optimizers_test.py
@@ -1,0 +1,65 @@
+# Copyright 2017 The TensorFlow Lattice Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Optimizers test."""
+# Dependency imports
+
+from tensorflow_lattice.python.estimators import calibrated_linear
+from tensorflow_lattice.python.estimators import hparams as tfl_hparams
+from tensorflow_lattice.python.estimators import optimizers as tfl_optimizers
+from tensorflow_lattice.python.lib import keypoints_initialization
+from tensorflow_lattice.python.lib import test_data
+
+from tensorflow.python.feature_column import feature_column as feature_column_lib
+from tensorflow.python.framework import test_util
+from tensorflow.python.platform import test
+
+
+_NUM_KEYPOINTS = 50
+
+
+class OptimizersTest(test_util.TensorFlowTestCase):
+
+  def setUp(self):
+    super(OptimizersTest, self).setUp()
+    self._test_data = test_data.TestData()
+
+  def _runCalibratedLinearRegressorTrainingWithOptimizer(self, optimizer_fn):
+    def init_fn():
+      return keypoints_initialization.uniform_keypoints_for_signal(
+          _NUM_KEYPOINTS, -1., 1., -1., 1.)
+    feature_names = ['x']
+    feature_columns = [feature_column_lib.numeric_column('x')]
+    hparams = tfl_hparams.CalibratedLinearHParams(
+        feature_names, num_keypoints=_NUM_KEYPOINTS,
+        learning_rate=0.1)
+    estimator = calibrated_linear.calibrated_linear_regressor(
+            feature_columns=feature_columns,
+            hparams=hparams,
+            keypoints_initializers_fn=init_fn,
+            optimizer=optimizer_fn)
+    estimator.train(input_fn=self._test_data.oned_input_fn())
+    _ = estimator.evaluate(input_fn=self._test_data.oned_input_fn())
+
+  def testCalibratedLinearRegressorWithSgd(self):
+    optimizer = tfl_optimizers.gradient_descent_polynomial_decay()
+    self._runCalibratedLinearRegressorTrainingWithOptimizer(optimizer)
+
+  def testCalibratedLinearRegressorWithSgd(self):
+    optimizer = tfl_optimizers.adagrad_polynomial_decay()
+    self._runCalibratedLinearRegressorTrainingWithOptimizer(optimizer)
+
+
+if __name__ == '__main__':
+  test.main()


### PR DESCRIPTION
SGD or Adagrad with a square root decay learning rate schedule can help training. Since TensorFlow lattice estimators accepts arbitrary callable as an optimizer, so we can use learning rate scheduling, but it is not easy to configure for a beginner. This pull requests include some helper functions and tests to illustrate how to use a custom learning rate schedule.

Also this pull requests include modify keep_dims argument to keepdims in linear model construction since tensorflow is deprecating a former argument.