### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorflow_lattice/python/configs.py
+++ b/tensorflow_lattice/python/configs.py
@@ -1025,7 +1025,7 @@ def apply_updates(model_config, updates):
   configs.apply_updates(model_config, updates)
   ```
 
-  Arguments:
+  Args:
     model_config: The model config object to apply the updates to.
     updates: A list of (key, value) pairs with potential config updates. Values
       that are not matched to a field in the model config will be ignored.

--- a/tensorflow_lattice/python/lattice_lib.py
+++ b/tensorflow_lattice/python/lattice_lib.py
@@ -2052,7 +2052,7 @@ def laplacian_regularizer(weights, lattice_sizes, l1=0.0, l2=0.0):
   l2[1] * ((w[3] - w[0])^2 + (w[4] - w[1])^2 + (w[5] - w[2])^2)
   ```
 
-  Arguments:
+  Args:
     weights: `Lattice` weights tensor of shape: `(prod(lattice_sizes), units)`.
     lattice_sizes: List or tuple of integers which represents lattice sizes.
     l1: l1 regularization amount. Either single float or list or tuple of floats
@@ -2129,7 +2129,7 @@ def torsion_regularizer(weights, lattice_sizes, l1=0.0, l2=0.0):
   l2 * ((w[4] + w[0] - w[3] - w[1])^2 + (w[5] + w[1] - w[4] - w[2])^2)
   ```
 
-  Arguments:
+  Args:
     weights: `Lattice` weights tensor of shape: `(prod(lattice_sizes), units)`.
     lattice_sizes: List or tuple of integers which represents lattice sizes.
     l1: l1 regularization amount. Either single float or list or tuple of floats


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420