### PR TITLE
setup.py fix sklearn → scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ _install_requires = [
     "numpy",
     "pandas",
     "six",
-    "sklearn",
+    "scikit-learn",
     "matplotlib",
     "graphviz",
     "dm-sonnet",


### PR DESCRIPTION
The package name is `scikit-learn` while the import is `sklearn`.

See https://pypi.org/project/sklearn/ for the official recommendation.

Requiring `sklearn` can lead to subtle problems as explained in https://github.com/scikit-learn/scikit-learn/issues/8215 .